### PR TITLE
Fix for Comparison between inconvertible types

### DIFF
--- a/apps/api/dev/testModelLiveProbes.ts
+++ b/apps/api/dev/testModelLiveProbes.ts
@@ -2141,7 +2141,7 @@ async function main() {
       const caps = new Set<ModelCapability>(declaredCaps);
       let endpointHintOverride: EndpointHint | undefined = undefined;
       const hintedEndpoint = probeHints.modelEndpointHints.get(model.id);
-      if (hintedEndpoint && hintedEndpoint !== endpointHintOverride) {
+      if (hintedEndpoint) {
         endpointHintOverride = hintedEndpoint;
       }
 


### PR DESCRIPTION
In general, to fix this type of problem, avoid comparing values whose types cannot meaningfully overlap. If one side of the comparison is guaranteed (by control flow or type declarations) not to be `undefined`, but the other is typed as possibly `undefined`, then either remove the unnecessary comparison or adjust the types/logic so both sides share a compatible type in the comparison.

In this specific case, the intention looks to be: if there is a hinted endpoint for this model, use it as an override. `endpointHintOverride` is initialized to `undefined` and is not changed before this block. The current code:

```ts
let endpointHintOverride: EndpointHint | undefined = undefined;
const hintedEndpoint = probeHints.modelEndpointHints.get(model.id);
if (hintedEndpoint && hintedEndpoint !== endpointHintOverride) {
  endpointHintOverride = hintedEndpoint;
}
```

The comparison to `endpointHintOverride` is redundant: at this point it is always `undefined`, and `hintedEndpoint` is truthy when entering the `if`. The simplest, behavior-preserving and type-correct fix is to drop the comparison and only guard on the presence of `hintedEndpoint`:

```ts
let endpointHintOverride: EndpointHint | undefined = undefined;
const hintedEndpoint = probeHints.modelEndpointHints.get(model.id);
if (hintedEndpoint) {
  endpointHintOverride = hintedEndpoint;
}
```

This keeps functionality (we still only set the override if a hint exists) while removing the meaningless comparison between incompatible/poorly-overlapping types that CodeQL flags. No new imports, methods, or additional definitions are required; all changes are confined to the shown region of `apps/api/dev/testModelLiveProbes.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._