### PR TITLE
feat(homepage): scroll-spy active-state on fixed nav

### DIFF
--- a/apps/homepage/public/index.html
+++ b/apps/homepage/public/index.html
@@ -123,6 +123,15 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
+  <style>
+    .nav-link-active {
+      font-weight: 700;
+      text-decoration: underline;
+      text-underline-offset: 4px;
+      text-decoration-thickness: 2px;
+      color: #62bfe7;
+    }
+  </style>
   <script src="https://cdn.jsdelivr.net/npm/keycloak-js@25.0.6/dist/keycloak.min.js"></script>
 </head>
 <body class="text-gray-100 font-sans">

--- a/apps/homepage/public/script.js
+++ b/apps/homepage/public/script.js
@@ -335,9 +335,55 @@ async function init() {
   }
 }
 
+function initScrollSpy() {
+  if (typeof IntersectionObserver === 'undefined') return;
+
+  const links = Array.from(document.querySelectorAll('nav a[href^="#"]'));
+  const sections = [];
+  for (const link of links) {
+    const section = document.getElementById(link.getAttribute('href').slice(1));
+    if (section) sections.push(section);
+  }
+  if (!sections.length) return;
+
+  let activeId = null;
+  const setActive = (id) => {
+    if (id === activeId) return;
+    activeId = id;
+    for (const link of links) {
+      const isActive = link.getAttribute('href') === '#' + id;
+      link.classList.toggle('nav-link-active', isActive);
+      if (isActive) link.setAttribute('aria-current', 'page');
+      else link.removeAttribute('aria-current');
+    }
+  };
+
+  const visible = new Set();
+  const observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (entry.isIntersecting) visible.add(entry.target.id);
+      else visible.delete(entry.target.id);
+    }
+    // Prefer the first section (in document order) currently inside the middle band.
+    const firstVisible = sections.find((s) => visible.has(s.id));
+    if (firstVisible) {
+      setActive(firstVisible.id);
+      return;
+    }
+    // Fallback: scrolled past the last section — keep the last nav link active.
+    const scrollBottom = window.scrollY + window.innerHeight;
+    if (scrollBottom >= document.documentElement.scrollHeight - 4) {
+      setActive(sections[sections.length - 1].id);
+    }
+  }, { rootMargin: '-40% 0px -40% 0px', threshold: 0 });
+
+  for (const section of sections) observer.observe(section);
+}
+
 // Run when DOM is ready
+const onReady = () => { init(); initScrollSpy(); };
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', init);
+  document.addEventListener('DOMContentLoaded', onReady);
 } else {
-  init();
+  onReady();
 }


### PR DESCRIPTION
## Summary

- Adds an `IntersectionObserver` (vanilla JS, no deps) to the marketing homepage so the fixed top nav highlights the link whose section is in the viewport's middle band (`rootMargin: -40% 0px -40% 0px`).
- The active link gets `aria-current="page"` and a `.nav-link-active` class (bold + underline + brand color), all others have those removed.
- When scrolled past the last section, the last nav link stays active.
- ~50 lines of JS appended to `apps/homepage/public/script.js`; ~9 lines of CSS in a `<style>` block in `apps/homepage/public/index.html`. No new dependencies.

## Test plan

- [x] `grep -F 'IntersectionObserver' apps/homepage/public/script.js` returns matches.
- [x] `grep -F 'nav-link-active' apps/homepage/public/{index.html,script.js}` returns matches in both files.
- [x] `node --check apps/homepage/public/script.js` parses cleanly.
- [ ] Manual scroll on the live homepage to confirm the active state advances through Features → Models → API.

Note: the local `bun run -F anygpt-homepage dev` step from the recipe couldn't bind to :3091 in the sandbox (express install constraints across the workspace at this revision), so verification fell back to file-grep + node syntax check, both passing.